### PR TITLE
Fix SP  spacing

### DIFF
--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -22,7 +22,7 @@ export default function ArticlesId({ articles }) {
 }
 
 const Main = styled.main`
-  max-width: 1440px;
+max-width: 100%;
 `;
 
 const Body = styled.div`
@@ -103,9 +103,9 @@ const Body = styled.div`
 
 const Title = styled.h1`
   display: block;
-  width: 900%;
+  width: 90%;
   margin: 0 auto;
-  margin: 30px 0;
+  padding-bottom: 30px;
   @media ${device.tablet}{
     width: 80%;
     font-size: ${font.lg};


### PR DESCRIPTION
スマホサイズの横幅が広がりすぎていて表示がおかしかったのでTitleのwidth 900%を90%に修正しました。